### PR TITLE
Add macOS compatibility using AppleScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This is a basic Now Playing TUI written in Go. I wanted a simple way to see what was playing on my Spotify account without having to open the app. This is a simple solution that uses playerctl to get the currently playing song and display it in the terminal. It even gives you basic controls to play/pause, skip, and go back.
+This is a basic Now Playing TUI written in Go. I wanted a simple way to see what was playing on my Spotify account without having to open the app. This cross-platform solution works on both Linux (using playerctl) and macOS (using AppleScript) to get the currently playing song and display it in the terminal. It even gives you basic controls to play/pause, skip, and go back.
 
 ![GoPlaying](assets/GoPlaying.jpeg)
 
@@ -15,12 +15,21 @@ You can install GoPlaying from the AUR with the package `goplaying-git`.
 yay -S goplaying-git
 ```
 
-### Manual
+### macOS
 
-### Dependencies
+GoPlaying works natively on macOS using AppleScript to control Spotify.
 
+#### Dependencies
+- go
+- Spotify app
+
+### Linux
+
+#### Dependencies
 - go
 - playerctl
+
+### Manual Installation
 
 1. Clone the repository
 ```bash

--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"bytes"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -32,60 +29,38 @@ type SongData struct {
 }
 
 type model struct {
-	songData  SongData
-	color     string
-	width     int
-	height    int
-	lastError error
+	songData       SongData
+	color          string
+	width          int
+	height         int
+	lastError      error
+	mediaController MediaController
 }
 
 type tickMsg struct{}
 
-func getSongInfo() (SongData, error) {
+func getSongInfo(mc MediaController) (SongData, error) {
 	var data SongData
 
-	cmd := exec.Command("playerctl", "metadata", "--format", "{{title}}|{{artist}}|{{album}}|{{status}}")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return data, errors.New("can't get metadata")
+	title, artist, album, status, err := mc.GetMetadata()
+	if err != nil {
+		return data, err
 	}
 
-	output := strings.TrimSpace(out.String())
-	if output == "" {
-		return data, errors.New("no song playing")
+	data.Title = truncateText(title, 30)
+	data.Artist = truncateText(artist, 30)
+	data.Album = truncateText(album, 30)
+	data.Status = status
+
+	duration, err := mc.GetDuration()
+	if err != nil {
+		return data, err
 	}
 
-	parts := strings.Split(output, "|")
-	if len(parts) != 4 {
-		return data, errors.New("unexpected metadata format")
+	position, err := mc.GetPosition()
+	if err != nil {
+		return data, err
 	}
-
-	data.Title = truncateText(strings.TrimSpace(parts[0]), 30)
-	data.Artist = truncateText(strings.TrimSpace(parts[1]), 30)
-	data.Album = truncateText(strings.TrimSpace(parts[2]), 30)
-	data.Status = strings.TrimSpace(parts[3])
-
-	cmd = exec.Command("playerctl", "metadata", "mpris:length")
-	out.Reset()
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return data, errors.New("can't get duration")
-	}
-
-	var duration int64
-	fmt.Sscanf(strings.TrimSpace(out.String()), "%d", &duration)
-	duration = duration / 1e6
-
-	cmd = exec.Command("playerctl", "position")
-	out.Reset()
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return data, errors.New("can't get position")
-	}
-
-	var position float64
-	fmt.Sscanf(strings.TrimSpace(out.String()), "%f", &position)
 
 	data.CurrentTime = formatTime(int64(position))
 	data.TotalTime = formatTime(duration)
@@ -118,17 +93,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q":
 			return m, tea.Quit
 		case "p":
-			controlPlayer("play-pause")
+			m.mediaController.Control("play-pause")
 		case "n":
-			controlPlayer("next")
+			m.mediaController.Control("next")
 		case "b":
-			controlPlayer("previous")
+			m.mediaController.Control("previous")
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
 	case tickMsg:
-		data, err := getSongInfo()
+		data, err := getSongInfo(m.mediaController)
 		if err != nil {
 			m.lastError = err
 		} else {
@@ -218,15 +193,12 @@ func (m model) View() string {
 	)
 }
 
-func controlPlayer(command string) error {
-	return exec.Command("playerctl", command).Run()
-}
-
 func main() {
 	flag.Parse()
 
 	initialModel := model{
-		color: colorFlag,
+		color:           colorFlag,
+		mediaController: NewMediaController(),
 	}
 
 	if _, err := tea.NewProgram(initialModel, tea.WithAltScreen()).Run(); err != nil {

--- a/main.go
+++ b/main.go
@@ -64,7 +64,13 @@ func getSongInfo(mc MediaController) (SongData, error) {
 
 	data.CurrentTime = formatTime(int64(position))
 	data.TotalTime = formatTime(duration)
-	data.Progress = position / float64(duration)
+
+	// Guard against division by zero
+	if duration > 0 {
+		data.Progress = position / float64(duration)
+	} else {
+		data.Progress = 0.0
+	}
 
 	return data, nil
 }
@@ -93,11 +99,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q":
 			return m, tea.Quit
 		case "p":
-			m.mediaController.Control("play-pause")
+			if err := m.mediaController.Control("play-pause"); err != nil {
+				m.lastError = err
+			}
 		case "n":
-			m.mediaController.Control("next")
+			if err := m.mediaController.Control("next"); err != nil {
+				m.lastError = err
+			}
 		case "b":
-			m.mediaController.Control("previous")
+			if err := m.mediaController.Control("previous"); err != nil {
+				m.lastError = err
+			}
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width

--- a/media.go
+++ b/media.go
@@ -1,0 +1,9 @@
+package main
+
+// MediaController defines the interface for controlling media playback across platforms
+type MediaController interface {
+	GetMetadata() (title, artist, album, status string, err error)
+	GetDuration() (int64, error)
+	GetPosition() (float64, error)
+	Control(command string) error
+}

--- a/media_darwin.go
+++ b/media_darwin.go
@@ -40,7 +40,7 @@ func (a *AppleScriptController) GetMetadata() (title, artist, album, status stri
 	// Get track information
 	script := `tell application "Spotify"
 		if player state is stopped then
-			return "||stopped"
+			error "no song playing"
 		end if
 		set trackName to name of current track
 		set trackArtist to artist of current track
@@ -51,7 +51,7 @@ func (a *AppleScriptController) GetMetadata() (title, artist, album, status stri
 
 	output, err := a.runAppleScript(script)
 	if err != nil {
-		return "", "", "", "", errors.New("can't get metadata")
+		return "", "", "", "", errors.New("no song playing")
 	}
 
 	if output == "" {

--- a/media_darwin.go
+++ b/media_darwin.go
@@ -102,7 +102,10 @@ func (a *AppleScriptController) GetPosition() (float64, error) {
 	}
 
 	var position float64
-	fmt.Sscanf(output, "%f", &position)
+	n, err := fmt.Sscanf(output, "%f", &position)
+	if err != nil || n != 1 {
+		return 0, errors.New("failed to parse position")
+	}
 
 	return position, nil
 }

--- a/media_darwin.go
+++ b/media_darwin.go
@@ -81,7 +81,10 @@ func (a *AppleScriptController) GetDuration() (int64, error) {
 	}
 
 	var duration int64
-	fmt.Sscanf(output, "%d", &duration)
+	n, err := fmt.Sscanf(output, "%d", &duration)
+	if err != nil || n != 1 {
+		return 0, errors.New("failed to parse duration")
+	}
 	// Convert from milliseconds to seconds
 	duration = duration / 1000
 

--- a/media_darwin.go
+++ b/media_darwin.go
@@ -1,0 +1,123 @@
+//go:build darwin
+// +build darwin
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// AppleScriptController implements MediaController using AppleScript for macOS
+type AppleScriptController struct{}
+
+// NewMediaController creates a new media controller for the current platform
+func NewMediaController() MediaController {
+	return &AppleScriptController{}
+}
+
+func (a *AppleScriptController) runAppleScript(script string) (string, error) {
+	cmd := exec.Command("osascript", "-e", script)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func (a *AppleScriptController) GetMetadata() (title, artist, album, status string, err error) {
+	// Check if Spotify is running
+	checkScript := `tell application "System Events" to (name of processes) contains "Spotify"`
+	result, err := a.runAppleScript(checkScript)
+	if err != nil || result != "true" {
+		return "", "", "", "", errors.New("Spotify is not running")
+	}
+
+	// Get track information
+	script := `tell application "Spotify"
+		if player state is stopped then
+			return "||stopped"
+		end if
+		set trackName to name of current track
+		set trackArtist to artist of current track
+		set trackAlbum to album of current track
+		set playerState to player state as string
+		return trackName & "|" & trackArtist & "|" & trackAlbum & "|" & playerState
+	end tell`
+
+	output, err := a.runAppleScript(script)
+	if err != nil {
+		return "", "", "", "", errors.New("can't get metadata")
+	}
+
+	if output == "" {
+		return "", "", "", "", errors.New("no song playing")
+	}
+
+	parts := strings.Split(output, "|")
+	if len(parts) != 4 {
+		return "", "", "", "", errors.New("unexpected metadata format")
+	}
+
+	return strings.TrimSpace(parts[0]),
+		strings.TrimSpace(parts[1]),
+		strings.TrimSpace(parts[2]),
+		strings.TrimSpace(parts[3]),
+		nil
+}
+
+func (a *AppleScriptController) GetDuration() (int64, error) {
+	script := `tell application "Spotify"
+		return duration of current track
+	end tell`
+
+	output, err := a.runAppleScript(script)
+	if err != nil {
+		return 0, errors.New("can't get duration")
+	}
+
+	var duration int64
+	fmt.Sscanf(output, "%d", &duration)
+	// Convert from milliseconds to seconds
+	duration = duration / 1000
+
+	return duration, nil
+}
+
+func (a *AppleScriptController) GetPosition() (float64, error) {
+	script := `tell application "Spotify"
+		return player position
+	end tell`
+
+	output, err := a.runAppleScript(script)
+	if err != nil {
+		return 0, errors.New("can't get position")
+	}
+
+	var position float64
+	fmt.Sscanf(output, "%f", &position)
+
+	return position, nil
+}
+
+func (a *AppleScriptController) Control(command string) error {
+	var script string
+
+	switch command {
+	case "play-pause":
+		script = `tell application "Spotify" to playpause`
+	case "next":
+		script = `tell application "Spotify" to next track`
+	case "previous":
+		script = `tell application "Spotify" to previous track`
+	default:
+		return fmt.Errorf("unknown command: %s", command)
+	}
+
+	_, err := a.runAppleScript(script)
+	return err
+}

--- a/media_linux.go
+++ b/media_linux.go
@@ -53,7 +53,10 @@ func (p *PlayerctlController) GetDuration() (int64, error) {
 	}
 
 	var duration int64
-	fmt.Sscanf(strings.TrimSpace(out.String()), "%d", &duration)
+	n, err := fmt.Sscanf(strings.TrimSpace(out.String()), "%d", &duration)
+	if n != 1 || err != nil {
+		return 0, errors.New("failed to parse duration")
+	}
 	// Convert from microseconds to seconds
 	duration = duration / 1e6
 

--- a/media_linux.go
+++ b/media_linux.go
@@ -1,0 +1,79 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// PlayerctlController implements MediaController using playerctl for Linux
+type PlayerctlController struct{}
+
+// NewMediaController creates a new media controller for the current platform
+func NewMediaController() MediaController {
+	return &PlayerctlController{}
+}
+
+func (p *PlayerctlController) GetMetadata() (title, artist, album, status string, err error) {
+	cmd := exec.Command("playerctl", "metadata", "--format", "{{title}}|{{artist}}|{{album}}|{{status}}")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", "", "", "", errors.New("can't get metadata")
+	}
+
+	output := strings.TrimSpace(out.String())
+	if output == "" {
+		return "", "", "", "", errors.New("no song playing")
+	}
+
+	parts := strings.Split(output, "|")
+	if len(parts) != 4 {
+		return "", "", "", "", errors.New("unexpected metadata format")
+	}
+
+	return strings.TrimSpace(parts[0]),
+		strings.TrimSpace(parts[1]),
+		strings.TrimSpace(parts[2]),
+		strings.TrimSpace(parts[3]),
+		nil
+}
+
+func (p *PlayerctlController) GetDuration() (int64, error) {
+	cmd := exec.Command("playerctl", "metadata", "mpris:length")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return 0, errors.New("can't get duration")
+	}
+
+	var duration int64
+	fmt.Sscanf(strings.TrimSpace(out.String()), "%d", &duration)
+	// Convert from microseconds to seconds
+	duration = duration / 1e6
+
+	return duration, nil
+}
+
+func (p *PlayerctlController) GetPosition() (float64, error) {
+	cmd := exec.Command("playerctl", "position")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return 0, errors.New("can't get position")
+	}
+
+	var position float64
+	fmt.Sscanf(strings.TrimSpace(out.String()), "%f", &position)
+
+	return position, nil
+}
+
+func (p *PlayerctlController) Control(command string) error {
+	return exec.Command("playerctl", command).Run()
+}

--- a/media_linux.go
+++ b/media_linux.go
@@ -72,7 +72,10 @@ func (p *PlayerctlController) GetPosition() (float64, error) {
 	}
 
 	var position float64
-	fmt.Sscanf(strings.TrimSpace(out.String()), "%f", &position)
+	n, err := fmt.Sscanf(strings.TrimSpace(out.String()), "%f", &position)
+	if n != 1 || err != nil {
+		return 0, errors.New("failed to parse position")
+	}
 
 	return position, nil
 }


### PR DESCRIPTION
- Created platform abstraction layer (MediaController interface)
- Implemented Linux backend using playerctl (media_linux.go)
- Implemented macOS backend using AppleScript (media_darwin.go)
- Refactored main.go to use platform-agnostic media controller
- Updated README with macOS installation instructions

The app now works cross-platform on both Linux and macOS without requiring playerctl on Mac.