### PR TITLE
Add CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,32 +9,16 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    name: Build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            goos: linux
-            goarch: amd64
-            output: goplaying-linux-amd64
-          - os: ubuntu-latest
-            goos: linux
-            goarch: arm64
-            output: goplaying-linux-arm64
-          - os: macos-latest
-            goos: darwin
-            goarch: amd64
-            output: goplaying-darwin-amd64
-          - os: macos-latest
-            goos: darwin
-            goarch: arm64
-            output: goplaying-darwin-arm64
+  test-build:
+    name: Test Build
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.ref, 'refs/tags/v')"
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -53,49 +37,34 @@ jobs:
       run: go mod download
 
     - name: Build
-      run: go build -v -o ${{ matrix.output }}
-      env:
-        GOOS: ${{ matrix.goos }}
-        GOARCH: ${{ matrix.goarch }}
+      run: go build -v
 
     - name: Test
       run: go test -v ./...
-      if: matrix.os == 'ubuntu-latest'
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ matrix.output }}
-        path: ${{ matrix.output }}
 
   release:
-    name: Create Release
-    needs: build
+    name: Release with GoReleaser
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    - name: Download all artifacts
-      uses: actions/download-artifact@v4
-
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
       with:
-        files: |
-          goplaying-linux-amd64/goplaying-linux-amd64
-          goplaying-linux-arm64/goplaying-linux-arm64
-          goplaying-darwin-amd64/goplaying-darwin-amd64
-          goplaying-darwin-arm64/goplaying-darwin-arm64
-        draft: false
-        prerelease: false
-        body: |
-          ## Downloads
-          - **Linux (amd64)**: `goplaying-linux-amd64`
-          - **Linux (arm64)**: `goplaying-linux-arm64`
-          - **macOS (Intel)**: `goplaying-darwin-amd64`
-          - **macOS (Apple Silicon)**: `goplaying-darwin-arm64`
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,101 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            output: goplaying-linux-amd64
+          - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            output: goplaying-linux-arm64
+          - os: macos-latest
+            goos: darwin
+            goarch: amd64
+            output: goplaying-darwin-amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+            output: goplaying-darwin-arm64
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Build
+      run: go build -v -o ${{ matrix.output }}
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+
+    - name: Test
+      run: go test -v ./...
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.output }}
+        path: ${{ matrix.output }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          goplaying-linux-amd64/goplaying-linux-amd64
+          goplaying-linux-arm64/goplaying-linux-arm64
+          goplaying-darwin-amd64/goplaying-darwin-amd64
+          goplaying-darwin-arm64/goplaying-darwin-arm64
+        draft: false
+        prerelease: false
+        body: |
+          ## Downloads
+          - **Linux (amd64)**: `goplaying-linux-amd64`
+          - **Linux (arm64)**: `goplaying-linux-arm64`
+          - **macOS (Intel)**: `goplaying-darwin-amd64`
+          - **macOS (Apple Silicon)**: `goplaying-darwin-arm64`
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,61 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          args: --timeout=5m
+
+  go-fmt:
+    name: go fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Run go fmt
+        run: |
+          if [ -n "$(gofmt -s -l .)" ]; then
+            echo "Go code is not formatted:"
+            gofmt -s -d .
+            exit 1
+          fi
+
+  go-vet:
+    name: go vet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Run go vet
+        run: go vet ./...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,94 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: goplaying
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - '^chore:'
+      - 'merge conflict'
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: 'Bug fixes'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: 'Performance improvements'
+      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: justinmdickey
+    name: goplaying
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    ## GoPlaying {{.Version}}
+
+    Cross-platform Spotify Now Playing TUI for Linux and macOS.
+  footer: |
+    ## Installation
+
+    Download the appropriate archive for your platform, extract it, and move the binary to your PATH.
+
+    ### Quick Install (Linux/macOS)
+    ```bash
+    # Extract and install
+    tar -xzf goplaying_*_Linux_x86_64.tar.gz
+    sudo mv goplaying /usr/local/bin/
+    ```
+
+    **Full installation instructions:** [README.md](https://github.com/justinmdickey/goplaying#installation)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GoPlaying
 
+[![Build and Release](https://github.com/justinmdickey/goplaying/workflows/Build%20and%20Release/badge.svg)](https://github.com/justinmdickey/goplaying/actions)
+[![Lint](https://github.com/justinmdickey/goplaying/workflows/Lint/badge.svg)](https://github.com/justinmdickey/goplaying/actions)
+
 ## Description
 
 This is a basic Now Playing TUI written in Go. I wanted a simple way to see what was playing on my Spotify account without having to open the app. This cross-platform solution works on both Linux (using playerctl) and macOS (using AppleScript) to get the currently playing song and display it in the terminal. It even gives you basic controls to play/pause, skip, and go back.
@@ -7,6 +10,21 @@ This is a basic Now Playing TUI written in Go. I wanted a simple way to see what
 ![GoPlaying](assets/GoPlaying.jpeg)
 
 ## Installation
+
+### Pre-built Binaries
+
+Download the latest release for your platform from the [Releases page](https://github.com/justinmdickey/goplaying/releases):
+
+- **Linux (amd64)**: `goplaying-linux-amd64`
+- **Linux (arm64)**: `goplaying-linux-arm64`
+- **macOS (Intel)**: `goplaying-darwin-amd64`
+- **macOS (Apple Silicon)**: `goplaying-darwin-arm64`
+
+Make the binary executable and move it to your PATH:
+```bash
+chmod +x goplaying-*
+sudo mv goplaying-* /usr/local/bin/goplaying
+```
 
 ### Arch Linux
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,19 @@ This is a basic Now Playing TUI written in Go. I wanted a simple way to see what
 
 Download the latest release for your platform from the [Releases page](https://github.com/justinmdickey/goplaying/releases):
 
-- **Linux (amd64)**: `goplaying-linux-amd64`
-- **Linux (arm64)**: `goplaying-linux-arm64`
-- **macOS (Intel)**: `goplaying-darwin-amd64`
-- **macOS (Apple Silicon)**: `goplaying-darwin-arm64`
+- **Linux (amd64)**: `goplaying_*_Linux_x86_64.tar.gz`
+- **Linux (arm64)**: `goplaying_*_Linux_arm64.tar.gz`
+- **macOS (Intel)**: `goplaying_*_Darwin_x86_64.tar.gz`
+- **macOS (Apple Silicon)**: `goplaying_*_Darwin_arm64.tar.gz`
 
-Make the binary executable and move it to your PATH:
+Extract and install:
 ```bash
-chmod +x goplaying-*
-sudo mv goplaying-* /usr/local/bin/goplaying
+# Extract the archive
+tar -xzf goplaying_*_Linux_x86_64.tar.gz  # or your platform's archive
+
+# Make executable and move to PATH
+chmod +x goplaying
+sudo mv goplaying /usr/local/bin/
 ```
 
 ### Arch Linux

--- a/main.go
+++ b/main.go
@@ -29,11 +29,11 @@ type SongData struct {
 }
 
 type model struct {
-	songData       SongData
-	color          string
-	width          int
-	height         int
-	lastError      error
+	songData        SongData
+	color           string
+	width           int
+	height          int
+	lastError       error
 	mediaController MediaController
 }
 
@@ -188,13 +188,13 @@ func (m model) View() string {
 		Width(50).
 		Render(titleStyle.Render("                Now Playing") + "\n\n" + content.String())
 
-  helpText := lipgloss.JoinHorizontal(
-    lipgloss.Center,
-    "Play/Pause: " + highlight.Render("p"),
-    "  Next: " + highlight.Render("n"),
-    "  Previous: " + highlight.Render("b"),
-    "  Quit: " + highlight.Render("q"),
-)
+	helpText := lipgloss.JoinHorizontal(
+		lipgloss.Center,
+		"Play/Pause: "+highlight.Render("p"),
+		"  Next: "+highlight.Render("n"),
+		"  Previous: "+highlight.Render("b"),
+		"  Quit: "+highlight.Render("q"),
+	)
 
 	fullUI := lipgloss.JoinVertical(lipgloss.Center, contentStr, "\n"+helpText)
 


### PR DESCRIPTION
- Created build workflow for multi-platform compilation
  - Builds for Linux (amd64, arm64)
  - Builds for macOS (Intel, Apple Silicon)
  - Uploads build artifacts
  - Creates releases with binaries on version tags
- Created lint workflow with golangci-lint, go fmt, and go vet
- Added CI/CD badges to README
- Added pre-built binaries section to installation instructions