### PR TITLE
Add Homebrew tap support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,3 +68,4 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,24 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+brews:
+  - name: goplaying
+    repository:
+      owner: justinmdickey
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/justinmdickey/goplaying"
+    description: "Cross-platform Spotify Now Playing TUI for Linux and macOS"
+    license: "MIT"
+    folder: Formula
+    install: |
+      bin.install "goplaying"
+    test: |
+      system "#{bin}/goplaying", "--version"
+    caveats: |
+      On macOS: Requires Spotify app (uses AppleScript)
+      On Linux: Requires playerctl to be installed separately
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ This is a basic Now Playing TUI written in Go. I wanted a simple way to see what
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
+The easiest way to install on macOS:
+
+```bash
+brew tap justinmdickey/tap
+brew install goplaying
+```
+
+**Note**: On macOS, requires Spotify app. On Linux, you'll need to install `playerctl` separately.
+
 ### Pre-built Binaries
 
 Download the latest release for your platform from the [Releases page](https://github.com/justinmdickey/goplaying/releases):


### PR DESCRIPTION
- Add brews configuration to .goreleaser.yml
  - Targets justinmdickey/homebrew-tap repository
  - Includes caveats for platform-specific dependencies
  - Auto-generates formula on each release
- Pass HOMEBREW_TAP_GITHUB_TOKEN to GoReleaser workflow
- Update README with Homebrew installation instructions
  - Position as primary installation method
  - Include note about dependencies

Users can now install with:
  brew tap justinmdickey/tap
  brew install goplaying