### PR TITLE
Fix GoReleaser v2 deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
       - -X main.date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - id: default
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
@@ -30,9 +30,9 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-    format_overrides:
-      - goos: windows
-        format: zip
+    formats:
+      - tar.gz
+      - zip
     files:
       - README.md
       - LICENSE
@@ -40,7 +40,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
-brews:
+homebrew:
   - name: goplaying
     repository:
       owner: justinmdickey
@@ -59,7 +59,7 @@ brews:
       On Linux: Requires playerctl to be installed separately
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
- Replace archives.format with archives.formats array
- Remove format_overrides in favor of formats list
- Change brews to homebrew (brews is deprecated)
- Replace snapshot.name_template with snapshot.version_template
- Add archive ID for better organization

All changes align with GoReleaser v2 best practices and eliminate deprecation warnings.