### PR TITLE
Simplify build workflow to only run on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,50 +2,13 @@ name: Build and Release
 
 on:
   push:
-    branches: [ main ]
     tags:
       - 'v*'
-  pull_request:
-    branches: [ main ]
 
 jobs:
-  test-build:
-    name: Test Build
-    runs-on: ubuntu-latest
-    if: "!startsWith(github.ref, 'refs/tags/v')"
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Download dependencies
-      run: go mod download
-
-    - name: Build
-      run: go build -v
-
-    - name: Test
-      run: go test -v ./...
-
   release:
     name: Release with GoReleaser
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
 


### PR DESCRIPTION
- Remove push to main and pull_request triggers
- Remove test-build job
- Only trigger release workflow on version tags (v*)
- Reduces CI usage and focuses builds on actual releases