### PR TITLE
Fix Nix flake to include all Go source files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
     fileset = lib.fileset.unions [
       ./go.mod
       ./go.sum
-      ./main.go
+      (lib.fileset.fileFilter (file: file.hasExt "go") ./.)
     ];
   };
 


### PR DESCRIPTION
The default.nix was only including main.go in the fileset, causing build failures since media.go, media_linux.go, and media_darwin.go were missing.

Changed to use fileFilter to automatically include all .go files in the source directory, making the build more robust and future-proof.