### PR TITLE
fix: Add thread-safe config access to prevent race conditions

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSafeConfigConcurrency tests that SafeConfig can be safely accessed from multiple goroutines
+func TestSafeConfigConcurrency(t *testing.T) {
+	sc := &SafeConfig{}
+
+	// Initial config
+	initialCfg := Config{}
+	initialCfg.UI.Color = "1"
+	initialCfg.UI.MaxWidth = 45
+	initialCfg.Artwork.Enabled = true
+	sc.Set(initialCfg)
+
+	var wg sync.WaitGroup
+
+	// Start 10 writers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				cfg := Config{}
+				cfg.UI.Color = string(rune('0' + (id % 10)))
+				cfg.UI.MaxWidth = 40 + id
+				cfg.Artwork.Enabled = (j % 2) == 0
+				sc.Set(cfg)
+			}
+		}(i)
+	}
+
+	// Start 10 readers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				cfg := sc.Get()
+				// Just access the fields to ensure no panic
+				_ = cfg.UI.Color
+				_ = cfg.UI.MaxWidth
+				_ = cfg.Artwork.Enabled
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// If we got here without panic or data race, test passes
+}
+
+// TestSafeConfigGetReturnsCopy tests that Get() returns a copy, not a reference
+func TestSafeConfigGetReturnsCopy(t *testing.T) {
+	sc := &SafeConfig{}
+
+	cfg1 := Config{}
+	cfg1.UI.Color = "1"
+	cfg1.UI.MaxWidth = 45
+	sc.Set(cfg1)
+
+	// Get a copy
+	retrieved1 := sc.Get()
+
+	// Modify the local copy
+	retrieved1.UI.Color = "2"
+	retrieved1.UI.MaxWidth = 100
+
+	// Get another copy - should have original values
+	retrieved2 := sc.Get()
+
+	if retrieved2.UI.Color != "1" {
+		t.Errorf("Expected color '1', got '%s'", retrieved2.UI.Color)
+	}
+
+	if retrieved2.UI.MaxWidth != 45 {
+		t.Errorf("Expected max_width 45, got %d", retrieved2.UI.MaxWidth)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes critical race condition in config access by wrapping the global config in a thread-safe `SafeConfig` wrapper with `sync.RWMutex`.

## Problem
The global `config` variable was being:
- **Read** by multiple goroutines: `View()`, `Update()`, `fetchSongData()`, background tickers
- **Written** by `viper.OnConfigChange()` during live config reload

This caused a data race that could lead to:
- Crashes during config reload
- Inconsistent config reads
- Undefined behavior

## Solution
- Created `SafeConfig` struct with `sync.RWMutex`
- Added `Get()` method for thread-safe reads (returns copy)
- Added `Set()` method for thread-safe writes
- Updated all ~27 config access points to use new API
- Get() returns copies to prevent external mutation

## Changes
- **main.go**: Added `SafeConfig` wrapper, updated all config accesses
- **config_test.go**: Added comprehensive unit tests with race detector

## Testing
```bash
# Run tests with race detector
go test -v -race ./config_test.go ./main.go ./media.go ./media_linux.go
```

Tests verify:
- ✅ Concurrent reads and writes don't cause panics or data races
- ✅ Get() returns copies, preventing external mutation
- ✅ 20 goroutines (10 readers, 10 writers) x 100 iterations each = no issues

## Performance Impact
- **Reads**: Minimal overhead (RLock + copy struct)
- **Writes**: Only during config reload (rare operation)
- **Overall**: Negligible impact, config reads are not in hot path

## Checklist
- [x] Code compiles without errors
- [x] Unit tests added and passing
- [x] Race detector clean
- [x] All config accesses updated
- [x] Resolves TODO.md critical priority #1

## Related
Closes first item in [TODO.md](https://github.com/justinmdickey/goplaying/blob/main/TODO.md#-critical-priority) critical priority list.