### PR TITLE
fix: Show friendly message when nothing is playing on Linux

### DIFF
--- a/media_linux.go
+++ b/media_linux.go
@@ -28,7 +28,9 @@ func (p *PlayerctlController) GetMetadata() (title, artist, album, status string
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
-		return "", "", "", "", fmt.Errorf("playerctl metadata failed: %w", err)
+		// When no player is running or nothing is playing, return friendly error
+		// that matches the "nothing playing" check in view.go
+		return "", "", "", "", errors.New("no song playing")
 	}
 
 	output := strings.TrimSpace(out.String())
@@ -53,7 +55,7 @@ func (p *PlayerctlController) GetDuration() (int64, error) {
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
-		return 0, fmt.Errorf("playerctl duration failed: %w", err)
+		return 0, errors.New("no song playing")
 	}
 
 	var duration int64
@@ -72,7 +74,7 @@ func (p *PlayerctlController) GetPosition() (float64, error) {
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
-		return 0, fmt.Errorf("playerctl position failed: %w", err)
+		return 0, errors.New("no song playing")
 	}
 
 	var position float64
@@ -97,7 +99,7 @@ func (p *PlayerctlController) GetArtwork() ([]byte, error) {
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("playerctl artwork metadata failed: %w", err)
+		return nil, errors.New("no artwork available")
 	}
 
 	artUrl := strings.TrimSpace(out.String())


### PR DESCRIPTION
## Summary
Fixes the ugly red error message that appears when no media player is active or nothing is playing on Linux.

## Problem
When nothing is playing, `playerctl` commands return exit code 1, which was displayed as:
```
Error: playerctl metadata failed: exit status 1
```

This error message didn't match any of the "nothing playing" checks in `view.go`, so it was shown as a red error instead of the graceful "Nothing playing" state.

## Solution
Updated `media_linux.go` to return friendly error messages that match the view layer's error checks:
- `GetMetadata()`: Returns `"no song playing"`
- `GetDuration()`: Returns `"no song playing"`
- `GetPosition()`: Returns `"no song playing"`
- `GetArtwork()`: Returns `"no artwork available"`

## Result
Users now see the friendly UI state:
- "󰓃 Now Playing" header
- "Nothing playing" in muted gray
- "Start playing music to begin" in dim text

No more ugly error messages when idle! 🎉

## Testing
- ✅ Tested with no players running - shows friendly message
- ✅ Tested with music playing - normal operation works correctly