### PR TITLE
fix: Use tab delimiter for playerctl metadata parsing

### DIFF
--- a/media_linux.go
+++ b/media_linux.go
@@ -24,7 +24,8 @@ func NewMediaController() MediaController {
 }
 
 func (p *PlayerctlController) GetMetadata() (title, artist, album, status string, err error) {
-	cmd := exec.Command("playerctl", "metadata", "--format", "{{title}}|{{artist}}|{{album}}|{{status}}")
+	// Use tab separator to avoid conflicts with | in metadata (e.g. album names like "Artist | Sessions")
+	cmd := exec.Command("playerctl", "metadata", "--format", "{{title}}\t{{artist}}\t{{album}}\t{{status}}")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
@@ -38,7 +39,7 @@ func (p *PlayerctlController) GetMetadata() (title, artist, album, status string
 		return "", "", "", "", errors.New("no song playing")
 	}
 
-	parts := strings.Split(output, "|")
+	parts := strings.Split(output, "\t")
 	if len(parts) != 4 {
 		return "", "", "", "", fmt.Errorf("unexpected metadata format: got %d parts, expected 4", len(parts))
 	}


### PR DESCRIPTION
## Summary
- Fixes metadata parsing failure when song metadata contains pipe characters (`|`)
- Album names like `Tyler Childers | OurVinyl Sessions` caused the parser to split into 5 parts instead of 4, producing: `unexpected metadata format: got 5 parts, expected 4`
- Switched the playerctl `--format` delimiter from `|` to `\t` (tab), which won't appear in song metadata

## Test plan
- [ ] Play a track with `|` in the album/title/artist name and verify it displays correctly
- [ ] Play a normal track and verify no regression in metadata parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)