### PR TITLE
feat: package nowplaying Swift helper in Homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,18 +45,18 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: nowplaying-darwin-arm64
-        path: dist/nowplaying-darwin-arm64
+        path: swift-helpers/nowplaying-darwin-arm64
 
     - name: Download Swift helper (x86_64)
       uses: actions/download-artifact@v4
       with:
         name: nowplaying-darwin-x86_64
-        path: dist/nowplaying-darwin-x86_64
+        path: swift-helpers/nowplaying-darwin-x86_64
 
     - name: Make helpers executable
       run: |
-        chmod +x dist/nowplaying-darwin-arm64/nowplaying
-        chmod +x dist/nowplaying-darwin-x86_64/nowplaying
+        chmod +x swift-helpers/nowplaying-darwin-arm64/nowplaying
+        chmod +x swift-helpers/nowplaying-darwin-x86_64/nowplaying
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,32 @@ on:
       - 'v*'
 
 jobs:
+  build-swift-helper:
+    name: Build Swift Helper (${{ matrix.arch }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [arm64, x86_64]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Compile nowplaying helper
+      run: |
+        swiftc -O -target ${{ matrix.arch }}-apple-macosx12.0 \
+          helpers/nowplaying/main.swift \
+          -o nowplaying
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: nowplaying-darwin-${{ matrix.arch }}
+        path: nowplaying
+
   release:
     name: Release with GoReleaser
     runs-on: ubuntu-latest
+    needs: build-swift-helper
     permissions:
       contents: write
 
@@ -17,6 +40,23 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
+    - name: Download Swift helper (arm64)
+      uses: actions/download-artifact@v4
+      with:
+        name: nowplaying-darwin-arm64
+        path: dist/nowplaying-darwin-arm64
+
+    - name: Download Swift helper (x86_64)
+      uses: actions/download-artifact@v4
+      with:
+        name: nowplaying-darwin-x86_64
+        path: dist/nowplaying-darwin-x86_64
+
+    - name: Make helpers executable
+      run: |
+        chmod +x dist/nowplaying-darwin-arm64/nowplaying
+        chmod +x dist/nowplaying-darwin-x86_64/nowplaying
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ go.work
 goplaying
 helpers/nowplaying/nowplaying
 vinyl_debug*.log
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ goplaying
 helpers/nowplaying/nowplaying
 vinyl_debug*.log
 .worktrees/
+swift-helpers/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,10 +6,10 @@ before:
     - go mod download
 
 builds:
-  - env:
+  - id: darwin
+    env:
       - CGO_ENABLED=0
     goos:
-      - linux
       - darwin
     goarch:
       - amd64
@@ -21,28 +21,49 @@ builds:
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
 
+  - id: linux
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    binary: goplaying
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
 archives:
-  - id: targz
+  - id: darwin-targz
+    builds:
+      - darwin
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
     format: tar.gz
     files:
       - README.md
       - LICENSE
-  - id: zip
+      - src: dist/nowplaying-darwin-{{ if eq .Arch "amd64" }}x86_64{{ else }}arm64{{ end }}/nowplaying
+        dst: .
+        strip_parent: true
+
+  - id: linux-targz
+    builds:
+      - linux
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-    format: zip
+    format: tar.gz
     files:
       - README.md
       - LICENSE
@@ -53,7 +74,7 @@ checksum:
 brews:
   - name: goplaying
     ids:
-      - targz
+      - darwin-targz
     repository:
       owner: justinmdickey
       name: homebrew-tap
@@ -64,15 +85,17 @@ brews:
     directory: Formula
     install: |
       bin.install "goplaying"
+      bin.install "nowplaying"
     test: |
       system "#{bin}/goplaying", "--version"
     caveats: |
-      macOS: 
-        - Album artwork works with Spotify and Apple Music via AppleScript
-        - For broader app support (Safari, Chrome, etc.), build the Swift helper with 'make darwin'
-      Linux: 
+      macOS:
+        - The nowplaying helper is included for broad Now Playing support
+          (Safari, Chrome, and any app that reports to macOS Media Center)
+        - Album artwork works with Spotify, Apple Music, and more
+      Linux:
+        - Install via GitHub releases (Homebrew formula is macOS-only)
         - Requires playerctl to be installed separately
-        - Album artwork works with any MPRIS player that provides artwork
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ archives:
     files:
       - README.md
       - LICENSE
-      - src: dist/nowplaying-darwin-{{ if eq .Arch "amd64" }}x86_64{{ else }}arm64{{ end }}/nowplaying
+      - src: swift-helpers/nowplaying-darwin-{{ if eq .Arch "amd64" }}x86_64{{ else }}arm64{{ end }}/nowplaying
         dst: .
         strip_parent: true
 


### PR DESCRIPTION
## Summary

Closes #46.

- Adds a macOS CI job that compiles the `nowplaying` Swift helper for both arm64 and x86_64
- Includes the helper binary in Darwin archives so Homebrew users get full Now Playing support (Safari, Chrome, etc.) without building from source
- Linux archives are unaffected

## Changes

- **`.github/workflows/build.yml`**: Added `build-swift-helper` matrix job (arm64/x86_64) on `macos-latest`, release job downloads artifacts before running GoReleaser
- **`.goreleaser.yml`**: Split into separate `darwin`/`linux` builds and archives; darwin archives include the `nowplaying` binary; Homebrew formula installs both binaries
- **`.gitignore`**: Added `.worktrees/` and `swift-helpers/` (CI staging directory)

## Test plan

- [x] Swift helper compiles for both arm64 and x86_64 on macOS runner
- [x] Darwin archives contain both `goplaying` and `nowplaying`
- [x] Linux archives contain only `goplaying`
- [x] GoReleaser completes successfully with clean git state
- [ ] Homebrew formula installs both binaries (`brew install justinmdickey/tap/goplaying`)