### PR TITLE
fix: Guard progress bar against negative strings.Repeat count

### DIFF
--- a/view.go
+++ b/view.go
@@ -91,7 +91,16 @@ func (m model) View() string {
 			// Progress bar with smooth interpolated position - will be placed below
 			// Bar width calculated from max_width, leaving room for timestamps
 			barWidth := cfg.UI.MaxWidth - 17
+			if barWidth < 0 {
+				barWidth = 0
+			}
+			if progress > 1 {
+				progress = 1
+			}
 			filled := int(float64(barWidth) * progress)
+			if filled > barWidth {
+				filled = barWidth
+			}
 			progressBar := highlight.Render(strings.Repeat("█", filled)) +
 				white.Render(strings.Repeat("─", barWidth-filled))
 


### PR DESCRIPTION
## Summary
- Fixes a panic (`strings: negative Repeat count`) at `view.go:96` that crashed the TUI after running for a while.
- Clamps `barWidth`, `progress`, and `filled` so `strings.Repeat` can't be called with a negative count.

## Root cause
At `view.go:93–96`, the progress bar computes `barWidth := cfg.UI.MaxWidth - 17` and `filled := int(float64(barWidth) * progress)`, then renders `strings.Repeat("─", barWidth-filled)`. If `cfg.UI.MaxWidth < 17` (live config reload via fsnotify means it can change at runtime) — or progress somehow exceeds 1.0 — `barWidth-filled` goes negative and `strings.Repeat` panics, taking down the program.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [ ] Verify with normal playback that the progress bar still renders correctly
- [ ] Verify a tiny `ui.max_width` (e.g. 10) no longer crashes