### PR TITLE
ci: automate AUR publishing for -bin and -git

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,54 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        AUR_KEY: ${{ secrets.AUR_KEY }}
+
+  update-aur-git:
+    name: Bump goplaying-git (AUR)
+    runs-on: ubuntu-latest
+    needs: release
+    container:
+      image: archlinux:base-devel
+    steps:
+    - name: Install dependencies
+      run: pacman -Syu --noconfirm git openssh sudo
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Compute pkgver from tagged commit
+      id: ver
+      run: |
+        count=$(git rev-list --count HEAD)
+        short=$(git rev-parse --short HEAD)
+        echo "pkgver=r${count}.${short}" >> "$GITHUB_OUTPUT"
+
+    - name: Clone, bump, and push AUR package
+      env:
+        AUR_KEY: ${{ secrets.AUR_KEY }}
+        PKGVER: ${{ steps.ver.outputs.pkgver }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        # makepkg refuses to run as root, so do everything as an unprivileged user.
+        useradd -m builder
+        install -d -m 700 -o builder -g builder /home/builder/.ssh
+        printf '%s\n' "$AUR_KEY" | install -m 600 -o builder -g builder /dev/stdin /home/builder/.ssh/aur
+        # `env` sets HOME + vars for builder's shell without relying on sudo -E / SETENV.
+        sudo -u builder env HOME=/home/builder PKGVER="$PKGVER" TAG="$TAG" \
+          bash -euo pipefail <<'EOF'
+        export GIT_SSH_COMMAND="ssh -i /home/builder/.ssh/aur -o StrictHostKeyChecking=accept-new"
+        git clone ssh://aur@aur.archlinux.org/goplaying-git.git /tmp/aur
+        cd /tmp/aur
+        sed -i "s/^pkgver=.*/pkgver=${PKGVER}/" PKGBUILD
+        grep -q "^pkgver=${PKGVER}$" PKGBUILD || { echo "pkgver bump failed to match PKGBUILD"; exit 1; }
+        makepkg --printsrcinfo > .SRCINFO
+        if git diff --quiet; then
+          echo "No changes to push"
+          exit 0
+        fi
+        git -c user.name=goplaying-releaser -c user.email=justin.dickey.eg@gmail.com \
+          commit -am "Update to ${PKGVER} (${TAG})"
+        git push
+        EOF

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,6 +97,32 @@ brews:
         - Install via GitHub releases (Homebrew formula is macOS-only)
         - Requires playerctl to be installed separately
 
+aurs:
+  - name: goplaying-bin
+    ids:
+      - linux-targz
+    homepage: "https://github.com/justinmdickey/goplaying"
+    description: "Now Playing TUI written in Go (binary release)"
+    license: "MIT"
+    maintainers:
+      - 'Justin Dickey <justin.dickey.eg@gmail.com>'
+    git_url: "ssh://aur@aur.archlinux.org/goplaying-bin.git"
+    private_key: "{{ .Env.AUR_KEY }}"
+    depends:
+      - playerctl
+    provides:
+      - goplaying
+    conflicts:
+      - goplaying
+      - goplaying-git
+    commit_author:
+      name: goplaying-releaser
+      email: justin.dickey.eg@gmail.com
+    commit_msg_template: "Update to {{ .Version }}"
+    package: |-
+      install -Dm755 "./goplaying" "${pkgdir}/usr/bin/goplaying"
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/goplaying-bin/LICENSE"
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
## Overview

Closes the manual AUR gap in the release pipeline. Tag push now updates both AUR packages automatically, matching the existing Homebrew + GitHub Release automation.

## Changes

**`.goreleaser.yml`** — new `aurs:` block for `goplaying-bin`. On tag push GoReleaser generates the PKGBUILD + `.SRCINFO` (correct sha256) for x86_64 and aarch64 and pushes to AUR over SSH.

**`.github/workflows/build.yml`**:
- `AUR_KEY` secret wired into the GoReleaser step.
- New `update-aur-git` job (arch container, after `release`): clones `goplaying-git`, bumps `pkgver` to `r<count>.<short>` from the tagged commit, regenerates `.SRCINFO` via `makepkg --printsrcinfo`, pushes. Runs as unprivileged `builder`; guards against a silent no-op sed.

## Verification
- `goreleaser check`: `aurs` block valid (pre-existing deprecation warnings on `archives`/`brews` unrelated).
- YAML parse OK.
- diff-reviewer: no blockers; two WARNs (HOME reset, sed guard) fixed.
- SSH key authenticates with AUR; `AUR_KEY` secret set.

## Notes / to review
- First run overwrites the hand-written `goplaying-bin/PKGBUILD` with GoReleaser's generated format (expected).
- `-git` bump runs only on release tags, not every main push.
- Effective only after merge + a new `v*` tag.

https://claude.ai/code/session_01M7k58o4AVCCvWAhdq4NGUe