### PR TITLE
fix: mark workspace safe in AUR git bump job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,8 @@ jobs:
     - name: Compute pkgver from tagged commit
       id: ver
       run: |
+        # Container runs git as root over checkout files owned by another uid.
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         count=$(git rev-list --count HEAD)
         short=$(git rev-parse --short HEAD)
         echo "pkgver=r${count}.${short}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

First automated release (v0.3.8) failed the `update-aur-git` job:

```
fatal: detected dubious ownership in repository at '/__w/goplaying/goplaying'
```

The arch container runs git as root over checkout files owned by another uid; git refuses until the path is whitelisted. The `Compute pkgver` step runs `git rev-list`/`git rev-parse` before that's configured.

GoReleaser path (Release, Homebrew, AUR `-bin`) was unaffected and published fine.

## Fix

Add `git config --global --add safe.directory "$GITHUB_WORKSPACE"` before the pkgver computation.

## Verify
- YAML parse OK.
- Full path re-verified by re-running the v0.3.8 tag after merge.

https://claude.ai/code/session_01M7k58o4AVCCvWAhdq4NGUe